### PR TITLE
[BUGFIX] define allowed HTTP methods through settings

### DIFF
--- a/Classes/Axovis/Neos/LanguageDetection/LanguageDetectionComponent.php
+++ b/Classes/Axovis/Neos/LanguageDetection/LanguageDetectionComponent.php
@@ -68,6 +68,11 @@ class LanguageDetectionComponent implements ComponentInterface {
             return;
         }
 
+        if (isset($this->options['allowedMethods']) && !in_array($httpRequest->getMethod(), $this->options['allowedMethods'])) {
+            //the current HTTP method is not within the allow methods, abort!
+            return;
+        }
+
         $preset = null;
         if(!isset($this->options['ignoreSegments']) || !in_array($firstRequestPathSegment, $this->options['ignoreSegments'])) {
             $preset = $this->findPreset($firstRequestPathSegment);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,3 +8,4 @@ TYPO3:
               component: 'Axovis\Neos\LanguageDetection\LanguageDetectionComponent'
               componentOptions:
                 ignoreSegments: ['neos','setup','_Resources','media']  #no language detection for this segments
+                allowedMethods: ['GET']


### PR DESCRIPTION
It is now possible to allow certain HTTP methods as optional setting. If this is not done, POST requests could be mistaken for for page requests that will receive a language redirect and this will eventually break forms.
