### PR TITLE
BUGFIX: Restore compatibilty with ``Neos.RedirectHandler`` package

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,7 +2,7 @@ TYPO3:
   Flow:
     http:
       chain:
-        'preprocess':
+        'process':
           chain:
             'detectLanguage':
               component: 'Axovis\Neos\LanguageDetection\LanguageDetectionComponent'


### PR DESCRIPTION
With this change the Neos core package`Neos.RedirectHandler` will keep working while the language detection still works.
